### PR TITLE
Add functionality to change the executionLevel inside the manifest

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,14 @@
+image:
+- Visual Studio 2015
+- Visual Studio 2013
+configuration: Default
+before_build:
+- cmd: |
+        git clone --depth 1 https://chromium.googlesource.com/external/gyp
+        gyp\gyp rcedit.gyp --depth .
+build:
+  project: rcedit.sln
+  parallel: true
+  verbosity: detailed
+artifacts:
+- path: Default\rcedit.exe

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ rcedit "path-to-exe-or-dll" --set-resource-string id_number "new string value"
 Set requestedExecutionLevel (asInvoker|highestAvailable|requireAdministrator) in the manifest:
 
 ```bash
-$ rcedit "path-to-exe-or-dll" --set-requested-execution-level "requireAdministrator"
+$ rcedit "path-to-exe-or-dll" --set-requestedExecutionLevel "requireAdministrator"
 ```
 
 And you can change multiple things in one command:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rcedit
+# rcedit [![Build status](https://ci.appveyor.com/api/projects/status/q0vyl3f9a387x9p6/branch/master?svg=true)](https://ci.appveyor.com/project/Atom/rcedit/branch/master)
 
 Command line tool to edit resources of exe file on Windows
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Set resource string:
 $ rcedit "path-to-exe-or-dll" --set-resource-string id_number "new string value"
 ```
 
+Set requestedExecutionLevel (asInvoker|highestAvailable|requireAdministrator) in the manifest:
+
+```bash
+$ rcedit "path-to-exe-or-dll" --set-requested-execution-level "requireAdministrator"
+```
+
 And you can change multiple things in one command:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rcedit [![Build status](https://ci.appveyor.com/api/projects/status/q0vyl3f9a387x9p6/branch/master?svg=true)](https://ci.appveyor.com/project/Atom/rcedit/branch/master)
+# rcedit [![Build status](https://ci.appveyor.com/api/projects/status/o8d047nebu8j94v3/branch/master?svg=true)](https://ci.appveyor.com/project/electron-bot/rcedit/branch/master)
 
 Command line tool to edit resources of exe file on Windows
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ rcedit "path-to-exe-or-dll" --set-resource-string id_number "new string value"
 Set requestedExecutionLevel (asInvoker|highestAvailable|requireAdministrator) in the manifest:
 
 ```bash
-$ rcedit "path-to-exe-or-dll" --set-requestedExecutionLevel "requireAdministrator"
+$ rcedit "path-to-exe-or-dll" --set-requested-execution-level "requireAdministrator"
 ```
 
 And you can change multiple things in one command:

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2013 GitHub, Inc. All rights reserved.
+﻿// Copyright (c) 2013 GitHub, Inc. All rights reserved.
 // Use of this source code is governed by MIT license that can be found in the
 // LICENSE file.
 
@@ -77,6 +77,15 @@ int wmain(int argc, const wchar_t* argv[]) {
 
       if (!updater.SetIcon(argv[++i]))
         return print_error("Unable to set icon");
+    }
+    else if (wcscmp(argv[i], L"--set-requested-executation-level") == 0 ||
+      wcscmp(argv[i], L"-sel") == 0) {
+      if (argc - i < 2)
+        return print_error("--set-requested-executation-level requires user, requireAdministrator or asInvoker");
+
+      if (!updater.SetExecutionLevel(argv[++i]))
+        return print_error("Unable to set execution level");
+
     } else if (wcscmp(argv[i], L"--set-resource-string") == 0 ||
       wcscmp(argv[i], L"--srs") == 0) {
       if (argc - i < 3)

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2013 GitHub, Inc. All rights reserved.
+// Copyright (c) 2013 GitHub, Inc. All rights reserved.
 // Use of this source code is governed by MIT license that can be found in the
 // LICENSE file.
 
@@ -77,15 +77,6 @@ int wmain(int argc, const wchar_t* argv[]) {
 
       if (!updater.SetIcon(argv[++i]))
         return print_error("Unable to set icon");
-    }
-    else if (wcscmp(argv[i], L"--set-requested-executation-level") == 0 ||
-      wcscmp(argv[i], L"-sel") == 0) {
-      if (argc - i < 2)
-        return print_error("--set-requested-executation-level requires user, requireAdministrator or asInvoker");
-
-      if (!updater.SetExecutionLevel(argv[++i]))
-        return print_error("Unable to set execution level");
-
     } else if (wcscmp(argv[i], L"--set-resource-string") == 0 ||
       wcscmp(argv[i], L"--srs") == 0) {
       if (argc - i < 3)

--- a/src/main.cc
+++ b/src/main.cc
@@ -47,7 +47,7 @@ int wmain(int argc, const wchar_t* argv[]) {
 
       unsigned short v1, v2, v3, v4;
       if (!parse_version_string(argv[++i], &v1, &v2, &v3, &v4))
-        return print_error("Unable to parse version string");
+        return print_error("Unable to parse version string for FileVersion");
 
       if (!updater.SetFileVersion(v1, v2, v3, v4))
         return print_error("Unable to change file version");
@@ -62,7 +62,7 @@ int wmain(int argc, const wchar_t* argv[]) {
 
       unsigned short v1, v2, v3, v4;
       if (!parse_version_string(argv[++i], &v1, &v2, &v3, &v4))
-        return print_error("Unable to parse version string");
+        return print_error("Unable to parse version string for ProductVersion");
 
       if (!updater.SetProductVersion(v1, v2, v3, v4))
         return print_error("Unable to change product version");

--- a/src/main.cc
+++ b/src/main.cc
@@ -11,6 +11,11 @@ bool print_error(const char* message) {
   return 1;
 }
 
+bool print_warning(const char* message) {
+  fprintf(stderr, "Warning: %s\n", message);
+  return 1;
+}
+
 bool parse_version_string(const wchar_t* str, unsigned short *v1, unsigned short *v2, unsigned short *v3, unsigned short *v4) {
   *v1 = *v2 = *v3 = *v4 = 0;
   if (swscanf_s(str, L"%hu.%hu.%hu.%hu", v1, v2, v3, v4) == 4)
@@ -82,12 +87,22 @@ int wmain(int argc, const wchar_t* argv[]) {
       if (argc - i < 2)
         return print_error("--set-requestedExecutionLevel requires asInvoker, highestAvailable or requireAdministrator");
 
+      if (updater.IsApplicationManifestSet())
+      {
+        print_warning("--set-requestedExecutionLevel is ignored if --application-manifest is set");
+      }
+
       if (!updater.SetExecutionLevel(argv[++i]))
         return print_error("Unable to set execution level");
     } else if (wcscmp(argv[i], L"--application-manifest") == 0 ||
       wcscmp(argv[i], L"-am") == 0) {
       if (argc - i < 2)
         return print_error("--application-manifest requires local path");
+
+      if (updater.IsExecutionLevelSet())
+      {
+        print_warning("--set-requestedExecutionLevel is ignored if --application-manifest is set");
+      }
 
       if (!updater.SetApplicationManifest(argv[++i]))
         return print_error("Unable to set application manifest");

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2013 GitHub, Inc. All rights reserved.
+﻿// Copyright (c) 2013 GitHub, Inc. All rights reserved.
 // Use of this source code is governed by MIT license that can be found in the
 // LICENSE file.
 
@@ -77,13 +77,20 @@ int wmain(int argc, const wchar_t* argv[]) {
 
       if (!updater.SetIcon(argv[++i]))
         return print_error("Unable to set icon");
-    } else if (wcscmp(argv[i], L"--set-requested-execution-level") == 0 || 
+    } else if (wcscmp(argv[i], L"--set-requestedExecutionLevel") == 0 || 
       wcscmp(argv[i], L"-sel") == 0) {
       if (argc - i < 2)
-        return print_error("--set-requested-execution-level requires user, requireAdministrator or asInvoker");
+        return print_error("--set-requestedExecutionLevel requires asInvoker, highestAvailable or requireAdministrator");
 
       if (!updater.SetExecutionLevel(argv[++i]))
         return print_error("Unable to set execution level");
+    } else if (wcscmp(argv[i], L"--application-manifest") == 0 ||
+      wcscmp(argv[i], L"-am") == 0) {
+      if (argc - i < 2)
+        return print_error("--application-manifest requires local path");
+
+      if (!updater.SetApplicationManifest(argv[++i]))
+        return print_error("Unable to set application manifest");
 
     } else if (wcscmp(argv[i], L"--set-resource-string") == 0 ||
       wcscmp(argv[i], L"--srs") == 0) {

--- a/src/main.cc
+++ b/src/main.cc
@@ -77,11 +77,10 @@ int wmain(int argc, const wchar_t* argv[]) {
 
       if (!updater.SetIcon(argv[++i]))
         return print_error("Unable to set icon");
-    }
-    else if (wcscmp(argv[i], L"--set-requested-executation-level") == 0 ||
+    } else if (wcscmp(argv[i], L"--set-requested-execution-level") == 0 || 
       wcscmp(argv[i], L"-sel") == 0) {
       if (argc - i < 2)
-        return print_error("--set-requested-executation-level requires user, requireAdministrator or asInvoker");
+        return print_error("--set-requested-execution-level requires user, requireAdministrator or asInvoker");
 
       if (!updater.SetExecutionLevel(argv[++i]))
         return print_error("Unable to set execution level");

--- a/src/main.cc
+++ b/src/main.cc
@@ -82,14 +82,14 @@ int wmain(int argc, const wchar_t* argv[]) {
 
       if (!updater.SetIcon(argv[++i]))
         return print_error("Unable to set icon");
-    } else if (wcscmp(argv[i], L"--set-requestedExecutionLevel") == 0 || 
+    } else if (wcscmp(argv[i], L"--set-requested-execution-level") == 0 || 
       wcscmp(argv[i], L"-sel") == 0) {
       if (argc - i < 2)
-        return print_error("--set-requestedExecutionLevel requires asInvoker, highestAvailable or requireAdministrator");
+        return print_error("--set-requested-execution-level requires asInvoker, highestAvailable or requireAdministrator");
 
       if (updater.IsApplicationManifestSet())
       {
-        print_warning("--set-requestedExecutionLevel is ignored if --application-manifest is set");
+        print_warning("--set-requested-execution-level is ignored if --application-manifest is set");
       }
 
       if (!updater.SetExecutionLevel(argv[++i]))
@@ -101,7 +101,7 @@ int wmain(int argc, const wchar_t* argv[]) {
 
       if (updater.IsExecutionLevelSet())
       {
-        print_warning("--set-requestedExecutionLevel is ignored if --application-manifest is set");
+        print_warning("--set-requested-execution-level is ignored if --application-manifest is set");
       }
 
       if (!updater.SetApplicationManifest(argv[++i]))

--- a/src/main.cc
+++ b/src/main.cc
@@ -77,6 +77,14 @@ int wmain(int argc, const wchar_t* argv[]) {
 
       if (!updater.SetIcon(argv[++i]))
         return print_error("Unable to set icon");
+    } else if (wcscmp(argv[i], L"--set-requested-execution-level") == 0 || 
+      wcscmp(argv[i], L"-sel") == 0) {
+      if (argc - i < 2)
+        return print_error("--set-requested-execution-level requires user, requireAdministrator or asInvoker");
+
+      if (!updater.SetExecutionLevel(argv[++i]))
+        return print_error("Unable to set execution level");
+
     } else if (wcscmp(argv[i], L"--set-resource-string") == 0 ||
       wcscmp(argv[i], L"--srs") == 0) {
       if (argc - i < 3)

--- a/src/main.cc
+++ b/src/main.cc
@@ -77,10 +77,11 @@ int wmain(int argc, const wchar_t* argv[]) {
 
       if (!updater.SetIcon(argv[++i]))
         return print_error("Unable to set icon");
-    } else if (wcscmp(argv[i], L"--set-requested-execution-level") == 0 || 
+    }
+    else if (wcscmp(argv[i], L"--set-requested-executation-level") == 0 ||
       wcscmp(argv[i], L"-sel") == 0) {
       if (argc - i < 2)
-        return print_error("--set-requested-execution-level requires user, requireAdministrator or asInvoker");
+        return print_error("--set-requested-executation-level requires user, requireAdministrator or asInvoker");
 
       if (!updater.SetExecutionLevel(argv[++i]))
         return print_error("Unable to set execution level");

--- a/src/rescle.cc
+++ b/src/rescle.cc
@@ -666,20 +666,41 @@ bool ResourceUpdater::Commit() {
       pos += executionLevel.length();
     }
 
-    //std::wstring wstr(manifestString.begin(), manifestString.end());
+    std::string wstr(manifestString.begin(), manifestString.end());
+    fprintf(stdout, "manifestString %s", wstr);
+
+    // clean old padding and add new padding, ensuring that the size is a multiple of 4
+    std::wstring::size_type padPos = wstr.find("</assembly>");
+    fprintf(stdout, "padPos %d %d", padPos, manifestString.length());
+    std::wstring trimmedStr = manifestString.substr(0, padPos + 11);
+
+    std::wstring padding = L"\n<!--Padding to make filesize even multiple of 4 X -->";
+
+    int offset = (trimmedStr.length() + padding.length()) % 4;
+    // multiple X by the number in offset
+    pos = 0u;
+    for (int posCount = 0; posCount < offset; posCount = posCount + 1)
+    {
+      if ((pos = padding.find(L"X", pos)) != std::string::npos) {
+        padding.replace(pos, 1, L"XX");
+        pos += executionLevel.length();
+      }
+    }
+    
+    
 
     std::vector<char> stringSection;
     stringSection.clear();
-    stringSection.push_back(manifestString.size());
-    stringSection.insert(stringSection.end(), manifestString.begin(), manifestString.end());
+    //stringSection.push_back(trimmedStr.size());
+    stringSection.insert(stringSection.end(), trimmedStr.begin(), trimmedStr.end());
+    stringSection.insert(stringSection.end(), padding.begin(), padding.end());
     
-    // not sure why I need to add +1 here, but it looks like the first character is the length.
     if (!UpdateResourceW
     (ru.Get()
       , RT_MANIFEST
       , MAKEINTRESOURCEW(1)
       , 1033
-      , &stringSection.at(0) + 1, sizeof(char) * manifestString.size())) {
+      , &stringSection.at(0), sizeof(char) * stringSection.size())) {
 
       return false;
     }

--- a/src/rescle.cc
+++ b/src/rescle.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2013 GitHub, Inc. All rights reserved.
+﻿// Copyright (c) 2013 GitHub, Inc. All rights reserved.
 // Use of this source code is governed by MIT license that can be found in the
 // LICENSE file.
 //
@@ -11,6 +11,8 @@
 #include <atlstr.h>
 #include <sstream> // wstringstream
 #include <iomanip> // setw, setfill
+#include <iostream>
+#include <string>
 
 namespace rescle {
 
@@ -438,7 +440,14 @@ bool ResourceUpdater::Load(const WCHAR* filename) {
   EnumResourceNamesW(hModule, RT_VERSION, OnEnumResourceName, reinterpret_cast<LONG_PTR>(this));
   EnumResourceNamesW(hModule, RT_GROUP_ICON, OnEnumResourceName, reinterpret_cast<LONG_PTR>(this));
   EnumResourceNamesW(hModule, RT_ICON, OnEnumResourceName, reinterpret_cast<LONG_PTR>(this));
+  EnumResourceNamesW(hModule, RT_MANIFEST, OnEnumResourceManifest, reinterpret_cast<LONG_PTR>(this));
 
+  return true;
+}
+
+bool ResourceUpdater::SetExecutionLevel(const WCHAR* value) {
+  std::wstring ws(value);
+  executionLevel = std::wstring(ws.begin(), ws.end());
   return true;
 }
 
@@ -642,6 +651,35 @@ bool ResourceUpdater::Commit() {
       , MAKEINTRESOURCEW(1)
       , langId
       , &out[0], static_cast<DWORD>(out.size()))) {
+
+      return false;
+    }
+  }
+
+  // update the execution level
+  if (!executionLevel.empty())
+  {
+    // string replace with requested executionLevel
+    std::wstring::size_type pos = 0u;
+    while ((pos = manifestString.find(original_executionLevel, pos)) != std::string::npos) {
+      manifestString.replace(pos, original_executionLevel.length(), executionLevel);
+      pos += executionLevel.length();
+    }
+
+    //std::wstring wstr(manifestString.begin(), manifestString.end());
+
+    std::vector<char> stringSection;
+    stringSection.clear();
+    stringSection.push_back(manifestString.size());
+    stringSection.insert(stringSection.end(), manifestString.begin(), manifestString.end());
+    
+    // not sure why I need to add +1 here, but it looks like the first character is the length.
+    if (!UpdateResourceW
+    (ru.Get()
+      , RT_MANIFEST
+      , MAKEINTRESOURCEW(1)
+      , 1033
+      , &stringSection.at(0) + 1, sizeof(char) * manifestString.size())) {
 
       return false;
     }
@@ -857,6 +895,33 @@ BOOL CALLBACK ResourceUpdater::OnEnumResourceLanguage(HANDLE hModule, LPCWSTR lp
 BOOL CALLBACK ResourceUpdater::OnEnumResourceName(HMODULE hModule, LPCWSTR lpszType, LPWSTR lpszName, LONG_PTR lParam) {
   EnumResourceLanguagesW(hModule, lpszType, lpszName, (ENUMRESLANGPROCW) OnEnumResourceLanguage, lParam);
   return TRUE;
+}
+
+// courtesy of http://stackoverflow.com/questions/420852/reading-an-applications-manifest-file
+BOOL CALLBACK ResourceUpdater::OnEnumResourceManifest(HMODULE hModule, LPCTSTR lpType,
+  LPWSTR lpName, LONG_PTR lParam)
+{
+  ResourceUpdater* instance = reinterpret_cast<ResourceUpdater*>(lParam);
+  HRSRC hResInfo = FindResource(hModule, lpName, lpType);
+  DWORD cbResource = SizeofResource(hModule, hResInfo);
+
+  HGLOBAL hResData = LoadResource(hModule, hResInfo);
+  const BYTE *pResource = (const BYTE *)LockResource(hResData);
+
+  int len = strlen(reinterpret_cast<const char*>(pResource));
+  std::wstring manifestStringLocal(pResource, pResource + len);
+  size_t found = manifestStringLocal.find(L"requestedExecutionLevel");
+  size_t end = manifestStringLocal.find(L"uiAccess");
+
+  instance->original_executionLevel = manifestStringLocal.substr(found +31 , end - found - 33);
+
+  // also store original manifestString
+  instance->manifestString = manifestStringLocal;
+
+  UnlockResource(hResData);
+  FreeResource(hResData);
+
+  return TRUE;   // Keep going
 }
 
 ScopedResourceUpdater::ScopedResourceUpdater(const wchar_t* filename, const bool& deleteOld)

--- a/src/rescle.cc
+++ b/src/rescle.cc
@@ -11,8 +11,6 @@
 #include <atlstr.h>
 #include <sstream> // wstringstream
 #include <iomanip> // setw, setfill
-#include <iostream>
-#include <string>
 #include <fstream>
 #include <codecvt>
 
@@ -448,17 +446,24 @@ bool ResourceUpdater::Load(const WCHAR* filename) {
 }
 
 bool ResourceUpdater::SetExecutionLevel(const WCHAR* value) {
-  std::wstring ws(value);
-  executionLevel = std::wstring(ws.begin(), ws.end());
+  executionLevel = value;
   return true;
+}
+
+bool ResourceUpdater::IsExecutionLevelSet()
+{
+  return !executionLevel.empty();
 }
 
 bool ResourceUpdater::SetApplicationManifest(const WCHAR* value) {
-  std::wstring ws(value);
-  applicationManifestPath = std::wstring(ws.begin(), ws.end());
+  applicationManifestPath = value;
   return true;
 }
 
+bool ResourceUpdater::IsApplicationManifestSet()
+{
+  return !applicationManifestPath.empty();
+}
 
 bool ResourceUpdater::SetVersionString(const WORD& languageId, const WCHAR* name, const WCHAR* value) {
   if (versionStampMap.find(languageId) == versionStampMap.end()) {
@@ -675,7 +680,7 @@ bool ResourceUpdater::Commit() {
   }
 
   // update the execution level
-  if (!executionLevel.empty())
+  if (applicationManifestPath.empty() && !executionLevel.empty())
   {
     // string replace with requested executionLevel
     std::wstring::size_type pos = 0u;

--- a/src/rescle.cc
+++ b/src/rescle.cc
@@ -666,10 +666,14 @@ bool ResourceUpdater::Commit() {
       pos += executionLevel.length();
     }
 
+    std::string wstr(manifestString.begin(), manifestString.end());
+    fprintf(stdout, "manifestString %s", wstr);
+
     // clean old padding and add new padding, ensuring that the size is a multiple of 4
-    std::wstring::size_type padPos = manifestString.find(L"</assembly>");
-    // trim anything after the </assembly>, 11 being the length of </assembly> (ie, remove old padding)
+    std::wstring::size_type padPos = wstr.find("</assembly>");
+    fprintf(stdout, "padPos %d %d", padPos, manifestString.length());
     std::wstring trimmedStr = manifestString.substr(0, padPos + 11);
+
     std::wstring padding = L"\n<!--Padding to make filesize even multiple of 4 X -->";
 
     int offset = (trimmedStr.length() + padding.length()) % 4;
@@ -683,9 +687,11 @@ bool ResourceUpdater::Commit() {
       }
     }
     
-    // convert the wchar back into char, so that it encodes correctly for Windows to read the XML.
+    
+
     std::vector<char> stringSection;
     stringSection.clear();
+    //stringSection.push_back(trimmedStr.size());
     stringSection.insert(stringSection.end(), trimmedStr.begin(), trimmedStr.end());
     stringSection.insert(stringSection.end(), padding.begin(), padding.end());
     
@@ -693,7 +699,7 @@ bool ResourceUpdater::Commit() {
     (ru.Get()
       , RT_MANIFEST
       , MAKEINTRESOURCEW(1)
-      , 1033 // this is hardcoded at 1033, ie, en-us, as that is what RT_MANIFEST default uses
+      , 1033
       , &stringSection.at(0), sizeof(char) * stringSection.size())) {
 
       return false;

--- a/src/rescle.cc
+++ b/src/rescle.cc
@@ -666,41 +666,20 @@ bool ResourceUpdater::Commit() {
       pos += executionLevel.length();
     }
 
-    std::string wstr(manifestString.begin(), manifestString.end());
-    fprintf(stdout, "manifestString %s", wstr);
-
-    // clean old padding and add new padding, ensuring that the size is a multiple of 4
-    std::wstring::size_type padPos = wstr.find("</assembly>");
-    fprintf(stdout, "padPos %d %d", padPos, manifestString.length());
-    std::wstring trimmedStr = manifestString.substr(0, padPos + 11);
-
-    std::wstring padding = L"\n<!--Padding to make filesize even multiple of 4 X -->";
-
-    int offset = (trimmedStr.length() + padding.length()) % 4;
-    // multiple X by the number in offset
-    pos = 0u;
-    for (int posCount = 0; posCount < offset; posCount = posCount + 1)
-    {
-      if ((pos = padding.find(L"X", pos)) != std::string::npos) {
-        padding.replace(pos, 1, L"XX");
-        pos += executionLevel.length();
-      }
-    }
-    
-    
+    //std::wstring wstr(manifestString.begin(), manifestString.end());
 
     std::vector<char> stringSection;
     stringSection.clear();
-    //stringSection.push_back(trimmedStr.size());
-    stringSection.insert(stringSection.end(), trimmedStr.begin(), trimmedStr.end());
-    stringSection.insert(stringSection.end(), padding.begin(), padding.end());
+    stringSection.push_back(manifestString.size());
+    stringSection.insert(stringSection.end(), manifestString.begin(), manifestString.end());
     
+    // not sure why I need to add +1 here, but it looks like the first character is the length.
     if (!UpdateResourceW
     (ru.Get()
       , RT_MANIFEST
       , MAKEINTRESOURCEW(1)
       , 1033
-      , &stringSection.at(0), sizeof(char) * stringSection.size())) {
+      , &stringSection.at(0) + 1, sizeof(char) * manifestString.size())) {
 
       return false;
     }

--- a/src/rescle.cc
+++ b/src/rescle.cc
@@ -666,14 +666,10 @@ bool ResourceUpdater::Commit() {
       pos += executionLevel.length();
     }
 
-    std::string wstr(manifestString.begin(), manifestString.end());
-    fprintf(stdout, "manifestString %s", wstr);
-
     // clean old padding and add new padding, ensuring that the size is a multiple of 4
-    std::wstring::size_type padPos = wstr.find("</assembly>");
-    fprintf(stdout, "padPos %d %d", padPos, manifestString.length());
+    std::wstring::size_type padPos = manifestString.find(L"</assembly>");
+    // trim anything after the </assembly>, 11 being the length of </assembly> (ie, remove old padding)
     std::wstring trimmedStr = manifestString.substr(0, padPos + 11);
-
     std::wstring padding = L"\n<!--Padding to make filesize even multiple of 4 X -->";
 
     int offset = (trimmedStr.length() + padding.length()) % 4;
@@ -687,11 +683,9 @@ bool ResourceUpdater::Commit() {
       }
     }
     
-    
-
+    // convert the wchar back into char, so that it encodes correctly for Windows to read the XML.
     std::vector<char> stringSection;
     stringSection.clear();
-    //stringSection.push_back(trimmedStr.size());
     stringSection.insert(stringSection.end(), trimmedStr.begin(), trimmedStr.end());
     stringSection.insert(stringSection.end(), padding.begin(), padding.end());
     
@@ -699,7 +693,7 @@ bool ResourceUpdater::Commit() {
     (ru.Get()
       , RT_MANIFEST
       , MAKEINTRESOURCEW(1)
-      , 1033
+      , 1033 // this is hardcoded at 1033, ie, en-us, as that is what RT_MANIFEST default uses
       , &stringSection.at(0), sizeof(char) * stringSection.size())) {
 
       return false;

--- a/src/rescle.cc
+++ b/src/rescle.cc
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2013 GitHub, Inc. All rights reserved.
+// Copyright (c) 2013 GitHub, Inc. All rights reserved.
 // Use of this source code is governed by MIT license that can be found in the
 // LICENSE file.
 //
@@ -11,8 +11,6 @@
 #include <atlstr.h>
 #include <sstream> // wstringstream
 #include <iomanip> // setw, setfill
-#include <iostream>
-#include <string>
 
 namespace rescle {
 
@@ -440,14 +438,7 @@ bool ResourceUpdater::Load(const WCHAR* filename) {
   EnumResourceNamesW(hModule, RT_VERSION, OnEnumResourceName, reinterpret_cast<LONG_PTR>(this));
   EnumResourceNamesW(hModule, RT_GROUP_ICON, OnEnumResourceName, reinterpret_cast<LONG_PTR>(this));
   EnumResourceNamesW(hModule, RT_ICON, OnEnumResourceName, reinterpret_cast<LONG_PTR>(this));
-  EnumResourceNamesW(hModule, RT_MANIFEST, OnEnumResourceManifest, reinterpret_cast<LONG_PTR>(this));
 
-  return true;
-}
-
-bool ResourceUpdater::SetExecutionLevel(const WCHAR* value) {
-  std::wstring ws(value);
-  executionLevel = std::wstring(ws.begin(), ws.end());
   return true;
 }
 
@@ -651,35 +642,6 @@ bool ResourceUpdater::Commit() {
       , MAKEINTRESOURCEW(1)
       , langId
       , &out[0], static_cast<DWORD>(out.size()))) {
-
-      return false;
-    }
-  }
-
-  // update the execution level
-  if (!executionLevel.empty())
-  {
-    // string replace with requested executionLevel
-    std::wstring::size_type pos = 0u;
-    while ((pos = manifestString.find(original_executionLevel, pos)) != std::string::npos) {
-      manifestString.replace(pos, original_executionLevel.length(), executionLevel);
-      pos += executionLevel.length();
-    }
-
-    //std::wstring wstr(manifestString.begin(), manifestString.end());
-
-    std::vector<char> stringSection;
-    stringSection.clear();
-    stringSection.push_back(manifestString.size());
-    stringSection.insert(stringSection.end(), manifestString.begin(), manifestString.end());
-    
-    // not sure why I need to add +1 here, but it looks like the first character is the length.
-    if (!UpdateResourceW
-    (ru.Get()
-      , RT_MANIFEST
-      , MAKEINTRESOURCEW(1)
-      , 1033
-      , &stringSection.at(0) + 1, sizeof(char) * manifestString.size())) {
 
       return false;
     }
@@ -895,33 +857,6 @@ BOOL CALLBACK ResourceUpdater::OnEnumResourceLanguage(HANDLE hModule, LPCWSTR lp
 BOOL CALLBACK ResourceUpdater::OnEnumResourceName(HMODULE hModule, LPCWSTR lpszType, LPWSTR lpszName, LONG_PTR lParam) {
   EnumResourceLanguagesW(hModule, lpszType, lpszName, (ENUMRESLANGPROCW) OnEnumResourceLanguage, lParam);
   return TRUE;
-}
-
-// courtesy of http://stackoverflow.com/questions/420852/reading-an-applications-manifest-file
-BOOL CALLBACK ResourceUpdater::OnEnumResourceManifest(HMODULE hModule, LPCTSTR lpType,
-  LPWSTR lpName, LONG_PTR lParam)
-{
-  ResourceUpdater* instance = reinterpret_cast<ResourceUpdater*>(lParam);
-  HRSRC hResInfo = FindResource(hModule, lpName, lpType);
-  DWORD cbResource = SizeofResource(hModule, hResInfo);
-
-  HGLOBAL hResData = LoadResource(hModule, hResInfo);
-  const BYTE *pResource = (const BYTE *)LockResource(hResData);
-
-  int len = strlen(reinterpret_cast<const char*>(pResource));
-  std::wstring manifestStringLocal(pResource, pResource + len);
-  size_t found = manifestStringLocal.find(L"requestedExecutionLevel");
-  size_t end = manifestStringLocal.find(L"uiAccess");
-
-  instance->original_executionLevel = manifestStringLocal.substr(found +31 , end - found - 33);
-
-  // also store original manifestString
-  instance->manifestString = manifestStringLocal;
-
-  UnlockResource(hResData);
-  FreeResource(hResData);
-
-  return TRUE;   // Keep going
 }
 
 ScopedResourceUpdater::ScopedResourceUpdater(const wchar_t* filename, const bool& deleteOld)

--- a/src/rescle.h
+++ b/src/rescle.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2013 GitHub, Inc. All rights reserved.
+// Copyright (c) 2013 GitHub, Inc. All rights reserved.
 // Use of this source code is governed by MIT license that can be found in the
 // LICENSE file.
 //
@@ -130,7 +130,6 @@ class ResourceUpdater {
   bool SetIcon(const WCHAR* path, const LANGID& langId, const UINT& iconBundle);
   bool SetIcon(const WCHAR* path, const LANGID& langId);
   bool SetIcon(const WCHAR* path);
-  bool SetExecutionLevel(const WCHAR* value);
   bool Commit();
 
   static bool UpdateRaw(const WCHAR* filename, const WORD& languageId, const WCHAR* type, const UINT& id, const void* data, const size_t& dataSize, const bool& deleteOld);
@@ -142,16 +141,11 @@ private:
   // not thread-safe
   static BOOL CALLBACK OnEnumResourceName(HMODULE hModule, LPCWSTR lpszType, LPWSTR lpszName, LONG_PTR lParam);
 
-  static BOOL CALLBACK OnEnumResourceManifest(HMODULE hModule, LPCWSTR lpszType, LPWSTR lpszName, LONG_PTR lParam);
-
   // not thread-safe
   static BOOL CALLBACK OnEnumResourceLanguage(HANDLE hModule, LPCWSTR lpszType, LPCWSTR lpszName, WORD wIDLanguage, LONG_PTR lParam);
 
   HMODULE hModule;
   std::wstring filename;
-  std::wstring executionLevel;
-  std::wstring original_executionLevel;
-  std::wstring manifestString;
   VersionStampMap versionStampMap;
   StringTableMap stringTableMap;
   IconTableMap iconBundleMap;

--- a/src/rescle.h
+++ b/src/rescle.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2013 GitHub, Inc. All rights reserved.
+﻿// Copyright (c) 2013 GitHub, Inc. All rights reserved.
 // Use of this source code is governed by MIT license that can be found in the
 // LICENSE file.
 //
@@ -131,6 +131,7 @@ class ResourceUpdater {
   bool SetIcon(const WCHAR* path, const LANGID& langId);
   bool SetIcon(const WCHAR* path);
   bool SetExecutionLevel(const WCHAR* value);
+  bool SetApplicationManifest(const WCHAR* value);
   bool Commit();
 
   static bool UpdateRaw(const WCHAR* filename, const WORD& languageId, const WCHAR* type, const UINT& id, const void* data, const size_t& dataSize, const bool& deleteOld);
@@ -150,6 +151,7 @@ private:
   HMODULE hModule;
   std::wstring filename;
   std::wstring executionLevel;
+  std::wstring applicationManifestPath;
   std::wstring original_executionLevel;
   std::wstring manifestString;
   VersionStampMap versionStampMap;

--- a/src/rescle.h
+++ b/src/rescle.h
@@ -131,7 +131,9 @@ class ResourceUpdater {
   bool SetIcon(const WCHAR* path, const LANGID& langId);
   bool SetIcon(const WCHAR* path);
   bool SetExecutionLevel(const WCHAR* value);
+  bool IsExecutionLevelSet();
   bool SetApplicationManifest(const WCHAR* value);
+  bool IsApplicationManifestSet();
   bool Commit();
 
   static bool UpdateRaw(const WCHAR* filename, const WORD& languageId, const WCHAR* type, const UINT& id, const void* data, const size_t& dataSize, const bool& deleteOld);

--- a/src/rescle.h
+++ b/src/rescle.h
@@ -130,6 +130,7 @@ class ResourceUpdater {
   bool SetIcon(const WCHAR* path, const LANGID& langId, const UINT& iconBundle);
   bool SetIcon(const WCHAR* path, const LANGID& langId);
   bool SetIcon(const WCHAR* path);
+  bool SetExecutionLevel(const WCHAR* value);
   bool Commit();
 
   static bool UpdateRaw(const WCHAR* filename, const WORD& languageId, const WCHAR* type, const UINT& id, const void* data, const size_t& dataSize, const bool& deleteOld);
@@ -141,11 +142,16 @@ private:
   // not thread-safe
   static BOOL CALLBACK OnEnumResourceName(HMODULE hModule, LPCWSTR lpszType, LPWSTR lpszName, LONG_PTR lParam);
 
+  static BOOL CALLBACK OnEnumResourceManifest(HMODULE hModule, LPCWSTR lpszType, LPWSTR lpszName, LONG_PTR lParam);
+
   // not thread-safe
   static BOOL CALLBACK OnEnumResourceLanguage(HANDLE hModule, LPCWSTR lpszType, LPCWSTR lpszName, WORD wIDLanguage, LONG_PTR lParam);
 
   HMODULE hModule;
   std::wstring filename;
+  std::wstring executionLevel;
+  std::wstring original_executionLevel;
+  std::wstring manifestString;
   VersionStampMap versionStampMap;
   StringTableMap stringTableMap;
   IconTableMap iconBundleMap;

--- a/src/rescle.h
+++ b/src/rescle.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2013 GitHub, Inc. All rights reserved.
+﻿// Copyright (c) 2013 GitHub, Inc. All rights reserved.
 // Use of this source code is governed by MIT license that can be found in the
 // LICENSE file.
 //
@@ -130,6 +130,7 @@ class ResourceUpdater {
   bool SetIcon(const WCHAR* path, const LANGID& langId, const UINT& iconBundle);
   bool SetIcon(const WCHAR* path, const LANGID& langId);
   bool SetIcon(const WCHAR* path);
+  bool SetExecutionLevel(const WCHAR* value);
   bool Commit();
 
   static bool UpdateRaw(const WCHAR* filename, const WORD& languageId, const WCHAR* type, const UINT& id, const void* data, const size_t& dataSize, const bool& deleteOld);
@@ -141,11 +142,16 @@ private:
   // not thread-safe
   static BOOL CALLBACK OnEnumResourceName(HMODULE hModule, LPCWSTR lpszType, LPWSTR lpszName, LONG_PTR lParam);
 
+  static BOOL CALLBACK OnEnumResourceManifest(HMODULE hModule, LPCWSTR lpszType, LPWSTR lpszName, LONG_PTR lParam);
+
   // not thread-safe
   static BOOL CALLBACK OnEnumResourceLanguage(HANDLE hModule, LPCWSTR lpszType, LPCWSTR lpszName, WORD wIDLanguage, LONG_PTR lParam);
 
   HMODULE hModule;
   std::wstring filename;
+  std::wstring executionLevel;
+  std::wstring original_executionLevel;
+  std::wstring manifestString;
   VersionStampMap versionStampMap;
   StringTableMap stringTableMap;
   IconTableMap iconBundleMap;


### PR DESCRIPTION
Hi,

I needed to be able to edit the manifest in the exe, as per https://github.com/electron-userland/electron-packager/issues/197.

I have added the code to make the changes to the manifest and have tested it by editing the executionLevel on rcedit.exe itself (it works).

I used Resource Hacker to confirm that the Manifest can be read by other applications as expected.

Cheers,

Damien
