### PR TITLE
Support for Windows XP and Server 2003

### DIFF
--- a/rcedit.gyp
+++ b/rcedit.gyp
@@ -7,6 +7,18 @@
       },{
         'msvs_express': 0,
       }],
+      ['OS=="win" and (MSVS_VERSION =="2012e" or MSVS_VERSION=="2012")', {
+        'msbuild_toolset': 'v110_xp',
+      }],
+      ['OS=="win" and (MSVS_VERSION=="2013e" or MSVS_VERSION=="2013")', {
+        'msbuild_toolset': 'v120_xp',
+      }],
+      ['OS=="win" and (MSVS_VERSION=="2015")', {
+        'msbuild_toolset': 'v140_xp',
+      }],
+      ['OS=="win" and (MSVS_VERSION=="2017")', {
+        'msbuild_toolset': 'v141_xp',
+      }],
     ],
   },
   'targets': [
@@ -30,6 +42,9 @@
         },
       },
       'conditions': [
+        ['OS=="win" and "<(msbuild_toolset)"!=""', {
+          'msbuild_toolset': '<(msbuild_toolset)',
+        }],
         # Using Visual Studio Express.
         ['msvs_express==1', {
           'defines!': [

--- a/rcedit.vcxproj
+++ b/rcedit.vcxproj
@@ -21,7 +21,7 @@
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Label="Locals">
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v120_xp</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props"/>
   <Import Project="$(VCTargetsPath)\BuildCustomizations\masm.props"/>


### PR DESCRIPTION
Use the toolset which compiles a binary suitable for Windows XP and Server 2003.

### Rationale

We are in a transition to move an internal web application hosted in an Chrome instance to an Electron shell based application.

The original application environment runs under Windows XP, the new environment will be based on Windows 10.

I know that Electron requires at least Windows 7 but I hoped that at least building our application is supported under Windows XP / Server 2003.
This is not the case:

```
Packaging app for platform win32 x64 using electron v1.6.7
internal/child_process.js:315
    throw errnoException(err, 'spawn');
    ^

Error: spawn UNKNOWN
    at exports._errnoException (util.js:907:11)
    at ChildProcess.spawn (internal/child_process.js:315:11)
    at exports.spawn (child_process.js:365:9)
    at module.exports (C:\development\work\project\node_modules\electron-packager\node_modules\rcedit\lib\rcedit.js:47:15)
    at C:\development\work\project\node_modules\electron-packager\win32.js:70:30
    at C:\development\work\project\node_modules\electron-packager\common.js:343:7
    at C:\development\work\project\node_modules\electron-packager\node_modules\fs-extra\node_modules\graceful-fs\polyfills.js:287:18
    at FSReqWrap.oncomplete (fs.js:82:15)

npm ERR! Windows_NT 5.2.3790
npm ERR! argv "C:\\development\\tools\\nodejs\\node.exe" "C:\\development\\tools\\nodejs\\node_modules\\npm\\bin\\npm-cli.js" "run" "pack:exe"
npm ERR! node v4.8.2
npm ERR! npm  v2.15.11
npm ERR! code ELIFECYCLE
npm ERR! Exit status 1
```

The error happens during spawning a new process for `rcedit.exe` - executed at CLI a message dialog pops up: 'rcedit.exe is not a valid Win32 application.'

[Dependency Walker](http://www.dependencywalker.com/) tells me that the function `InitializeCriticalSectionEx` is missing in `kernel32.dll` - it was [introduced in Windows Vista](https://msdn.microsoft.com/de-de/library/windows/desktop/ms683477(v=vs.85).aspx).

### Solution

Microsoft anticipated the need to create C++ application for Windows XP so they provided a [possibility to create C++ programs for Windows XP](https://msdn.microsoft.com/de-de/library/jj851139(v=vs.120).aspx): The Visual Studio project has to be configured to use a special `Platform Toolset`:

Microsoft provides an XP version of the `Platform Toolset` for every Visual Studio version since 2012:

* `Visual Studio 2012 (v110)` and `Visual Studio 2012 - Windows XP (v110_xp)`

* `Visual Studio 2013 (v120)` and `Visual Studio 2013 - Windows XP (v120_xp)`

* `Visual Studio 2015 (v140)` and `Visual Studio 2015 - Windows XP (v140_xp)`

* `Visual Studio 2017 (v141)` and `Visual Studio 2017 - Windows XP (v141_xp)`

There are some limitations: 
* Visual Studio 2015 requires an [additional install option](http://stackoverflow.com/a/35666906)
* Visual Studio 2012 requires [Update 1 to support this](https://blogs.msdn.microsoft.com/vcblog/2012/10/08/windows-xp-targeting-with-c-in-visual-studio-2012/).


I updated the `rcedit.gyp` to set the appropriate toolset version according to the detected Visual Studio version when generating the project files.
Also I tweaked the existing `rcedit.vcxproj` to compile the project with XP support.

I tested the compilation with Visual Studio 2013, Visual Studio 2015 and Visual Studio 2017 - all versions produced a binary which can be executed under Windows XP and Server 2003 (I tested with Server 2003).

All tests of https://github.com/electron/node-rcedit are green with the modified version of `rcedit.exe`.

Using this patched version of `rcedit.exe` would allow us to create our Electron shell based application under Windows XP based OSs.

This is just an attempt to make the build process work on older versions of Windows.
As I mentioned: we are in the process to migrate to a current version of Windows. This requires updates/changes to our development environment, our CI systems and our production systems. This will take some time - accepting this patch would relieve our pressure (at least a little bit).