### PR TITLE
Add help message

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ If you have modified the gyp files, you should regenerate the solution files:
 
 ## Docs
 
+Show help:
+
+```bash
+$ rcedit -h
+```
+
 Set version string:
 
 ```bash

--- a/rcedit.gyp
+++ b/rcedit.gyp
@@ -8,6 +8,7 @@
         'src/rescle.cc',
         'src/rescle.h',
         'src/rcedit.rc',
+        'src/version.h',
       ],
       'msvs_settings': {
         'VCLinkerTool': {

--- a/src/main.cc
+++ b/src/main.cc
@@ -5,8 +5,13 @@
 #include <string.h>
 
 #include "rescle.h"
+#include "version.h"
 
 namespace {
+
+void print_help() {
+  fprintf(stdout, "Rcedit " RCEDIT_VERSION ":\n");
+}
 
 bool print_error(const char* message) {
   fprintf(stderr, "Fatal error: %s\n", message);
@@ -31,6 +36,13 @@ bool parse_version_string(const wchar_t* str, unsigned short *v1, unsigned short
 int wmain(int argc, const wchar_t* argv[]) {
   bool loaded = false;
   rescle::ResourceUpdater updater;
+
+  if (argc == 1 ||
+      (argc == 2 && wcscmp(argv[1], L"-h") == 0) ||
+      (argc == 2 && wcscmp(argv[1], L"--help") == 0)) {
+    print_help();
+    return 0;
+  }
 
   for (int i = 1; i < argc; ++i) {
     if (wcscmp(argv[i], L"--set-version-string") == 0 ||
@@ -99,9 +111,7 @@ int wmain(int argc, const wchar_t* argv[]) {
         return print_error("--set-requested-execution-level requires asInvoker, highestAvailable or requireAdministrator");
 
       if (updater.IsApplicationManifestSet())
-      {
         print_warning("--set-requested-execution-level is ignored if --application-manifest is set");
-      }
 
       if (!updater.SetExecutionLevel(argv[++i]))
         return print_error("Unable to set execution level");
@@ -112,9 +122,7 @@ int wmain(int argc, const wchar_t* argv[]) {
         return print_error("--application-manifest requires local path");
 
       if (updater.IsExecutionLevelSet())
-      {
         print_warning("--set-requested-execution-level is ignored if --application-manifest is set");
-      }
 
       if (!updater.SetApplicationManifest(argv[++i]))
         return print_error("Unable to set application manifest");

--- a/src/main.cc
+++ b/src/main.cc
@@ -142,8 +142,10 @@ int wmain(int argc, const wchar_t* argv[]) {
         return print_error("Unable to change string");
 
     } else {
-      if (loaded)
-        return print_error("Unexpected trailing arguments");
+      if (loaded) {
+        fprintf(stderr, "Unrecognized argument: \"%ls\"\n", argv[i]);
+        return 1;
+      }
 
       loaded = true;
       if (!updater.Load(argv[i])) {

--- a/src/main.cc
+++ b/src/main.cc
@@ -10,7 +10,19 @@
 namespace {
 
 void print_help() {
-  fprintf(stdout, "Rcedit " RCEDIT_VERSION ":\n");
+  fprintf(stdout,
+"Rcedit " RCEDIT_VERSION ": Edit resources of exe.\n\n"
+"Usage: rcedit <filename> [options...]\n\n"
+"Options:\n"
+"  -h, --help                                 Show this message\n"
+"  --set-version-string <key> <value>         Set version string\n"
+"  --get-version-string <key>                 Print version string\n"
+"  --set-file-version <version>               Set FileVersion\n"
+"  --set-product-version <version>            Set ProductVersion\n"
+"  --set-icon <path-to-icon>                  Set file icon\n"
+"  --set-requested-execution-level <level>    Pass nothing to see usage\n"
+"  --application-manifest <path-to-file>      Set manifest file\n"
+"  --set-resource-string <key> <value>        Set resource string\n");
 }
 
 bool print_error(const char* message) {

--- a/src/main.cc
+++ b/src/main.cc
@@ -146,8 +146,10 @@ int wmain(int argc, const wchar_t* argv[]) {
         return print_error("Unexpected trailing arguments");
 
       loaded = true;
-      if (!updater.Load(argv[i]))
-        return print_error("Unable to load file");
+      if (!updater.Load(argv[i])) {
+        fprintf(stderr, "Unable to load file: \"%ls\"\n", argv[i]);
+        return 1;
+      }
 
     }
   }

--- a/src/version.h
+++ b/src/version.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2017 GitHub, Inc. All rights reserved.
+// Use of this source code is governed by MIT license that can be found in the
+// LICENSE file.
+
+#ifndef SRC_VERSION_H_
+#define SRC_VERSION_H_
+
+#define RCEDIT_MAJOR_VERSION 0
+#define RCEDIT_MINOR_VERSION 2
+#define RCEDIT_PATCH_VERSION 0
+
+#ifndef RCEDIT_TAG
+# define RCEDIT_TAG ""
+#endif
+
+#ifndef RCEDIT_STRINGIFY
+#define RCEDIT_STRINGIFY(n) RCEDIT_STRINGIFY_HELPER(n)
+#define RCEDIT_STRINGIFY_HELPER(n) #n
+#endif
+
+#define RCEDIT_VERSION_STRING  RCEDIT_STRINGIFY(RCEDIT_MAJOR_VERSION) "." \
+                               RCEDIT_STRINGIFY(RCEDIT_MINOR_VERSION) "." \
+                               RCEDIT_STRINGIFY(RCEDIT_PATCH_VERSION)     \
+                               RCEDIT_TAG
+
+#define RCEDIT_VERSION "v" RCEDIT_VERSION_STRING
+
+#endif  // SRC_VERSION_H_


### PR DESCRIPTION
```
$ ./Default/rcedit.exe
Rcedit v0.2.0: Edit resources of exe.

Usage: rcedit <filename> [options...]

Options:
  -h, --help                                 Show this message
  --set-version-string <key> <value>         Set version string
  --get-version-string <key>                 Print version string
  --set-file-version <version>               Set FileVersion
  --set-product-version <version>            Set ProductVersion
  --set-icon <path-to-icon>                  Set file icon
  --set-requested-execution-level <level>    Pass nothing to see usage
  --application-manifest <path-to-file>      Set manifest file
  --set-resource-string <key> <value>        Set resource string
```