### PR TITLE
Added RCDATA replacing by "--set-rcdata" key

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -23,7 +23,8 @@ void print_help() {
 "  --set-requested-execution-level <level>    Pass nothing to see usage\n"
 "  --application-manifest <path-to-file>      Set manifest file\n"
 "  --set-resource-string <key> <value>        Set resource string\n"
-"  --get-resource-string <key>                Get resource string\n");
+"  --get-resource-string <key>                Get resource string\n"
+"  --set-rcdata <key> <path-to-file>          Replace RCDATA by integer id\n");
 }
 
 bool print_error(const char* message) {
@@ -154,6 +155,18 @@ int wmain(int argc, const wchar_t* argv[]) {
       if (!updater.ChangeString(key_id, value))
         return print_error("Unable to change string");
 
+    } else if (wcscmp(argv[i], L"--set-rcdata") == 0) {
+      if (argc - i < 3)
+        return print_error("--set-rcdata requires int 'Key' and path to resource 'Value'");
+
+      const wchar_t* key = argv[++i];
+      unsigned int key_id = 0;
+      if (swscanf_s(key, L"%d", &key_id) != 1)
+        return print_error("Unable to parse id");
+
+      const wchar_t* pathToResource = argv[++i];
+      if (!updater.ChangeRcData(key_id, pathToResource))
+        return print_error("Unable to change RCDATA");
     } else if (wcscmp(argv[i], L"--get-resource-string") == 0 ||
       wcscmp(argv[i], L"-grs") == 0) {
       if (argc - i < 2)

--- a/src/rescle.h
+++ b/src/rescle.h
@@ -109,6 +109,9 @@ class ResourceUpdater {
   typedef std::map<WORD, StringTable> StringTableMap;
   typedef std::map<LANGID, VersionInfo> VersionStampMap;
   typedef std::map<UINT, std::unique_ptr<IconsValue>> IconTable;
+  typedef std::vector<BYTE> RcDataValue;
+  typedef std::map<ptrdiff_t, RcDataValue> RcDataMap;
+  typedef std::map<LANGID, RcDataMap> RcDataLangMap;
 
   struct IconResInfo {
     UINT maxIconId = 0;
@@ -131,6 +134,7 @@ class ResourceUpdater {
   bool SetFileVersion(unsigned short v1, unsigned short v2, unsigned short v3, unsigned short v4);
   bool ChangeString(WORD languageId, UINT id, const WCHAR* value);
   bool ChangeString(UINT id, const WCHAR* value);
+  bool ChangeRcData(UINT id, const WCHAR* pathToResource);
   const WCHAR* GetString(WORD languageId, UINT id);
   const WCHAR* GetString(UINT id);
   bool SetIcon(const WCHAR* path, const LANGID& langId, UINT iconBundle);
@@ -158,6 +162,7 @@ class ResourceUpdater {
   VersionStampMap versionStampMap_;
   StringTableMap stringTableMap_;
   IconTableMap iconBundleMap_;
+  RcDataLangMap rcDataLngMap_;
 };
 
 class ScopedResourceUpdater {


### PR DESCRIPTION
We need this feature to replace images and XML files embedded into our `*.exe` installers (online installers).

`--set-rcdata` option expects filepath - this path will be read as binary and embed as RCDATA resource with given ID
RCDATA resource with such ID must exist before rcedit will try to replace it.