### PR TITLE
fix: loadwrong chars at head of the manifest.

### DIFF
--- a/src/rescle.cc
+++ b/src/rescle.cc
@@ -885,6 +885,12 @@ BOOL CALLBACK ResourceUpdater::OnEnumResourceManifest(HMODULE hModule, LPCTSTR l
 
   int len = strlen(reinterpret_cast<const char*>(pResource));
   std::wstring manifestStringLocal(pResource, pResource + len);
+  
+  size_t start = manifestStringLocal.find(L"<?xml");
+  if (start > 0) {
+    manifestStringLocal = manifestStringLocal.substr(start);
+  }
+  
   size_t found = manifestStringLocal.find(L"requestedExecutionLevel");
   size_t end = manifestStringLocal.find(L"uiAccess");
 


### PR DESCRIPTION
when load manifest from electron exe(2.0.9) on the  windows 10 , there whill be some unexcepted chars at the head. This will cause the target exe broken

![image](https://user-images.githubusercontent.com/18594643/45595474-f808ba80-b9de-11e8-9d5b-daa30d9013e8.png)

