### PR TITLE
fix: print full paths in error messages

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,4 @@
-image:
-  - Visual Studio 2017
+image: Visual Studio 2017
 
 configuration: Default
 

--- a/src/rescle.cc
+++ b/src/rescle.cc
@@ -587,24 +587,24 @@ bool ResourceUpdater::SetIcon(const WCHAR* path, const LANGID& langId,
 
   ScopedFile file(path);
   if (file == INVALID_HANDLE_VALUE) {
-    fprintf(stderr, "Cannot open icon file '%s'\n", path);
+    fwprintf(stderr, "Cannot open icon file '%s'\n", path);
     return false;
   }
 
   IconsValue::ICONHEADER& header = icon.header;
   if (!ReadFile(file, &header, 3 * sizeof(WORD), &bytes, NULL)) {
-    fprintf(stderr, "Cannot read icon header for '%s'\n", path);
+    fwprintf(stderr, "Cannot read icon header for '%s'\n", path);
     return false;
   }
 
   if (header.reserved != 0 || header.type != 1) {
-    fprintf(stderr, "Reserved header is not 0 or image type is not icon for '%s'\n", path);
+    fwprintf(stderr, "Reserved header is not 0 or image type is not icon for '%s'\n", path);
     return false;
   }
 
   header.entries.resize(header.count);
   if (!ReadFile(file, header.entries.data(), header.count * sizeof(IconsValue::ICONENTRY), &bytes, NULL)) {
-    fprintf(stderr, "Cannot read icon metadata for '%s'\n", path);
+    fwprintf(stderr, "Cannot read icon metadata for '%s'\n", path);
     return false;
   }
 
@@ -613,7 +613,7 @@ bool ResourceUpdater::SetIcon(const WCHAR* path, const LANGID& langId,
     icon.images[i].resize(header.entries[i].bytesInRes);
     SetFilePointer(file, header.entries[i].imageOffset, NULL, FILE_BEGIN);
     if (!ReadFile(file, icon.images[i].data(), icon.images[i].size(), &bytes, NULL)) {
-      fprintf(stderr, "Cannot read icon data for '%s'\n", path);
+      fwprintf(stderr, "Cannot read icon data for '%s'\n", path);
       return false;
     }
   }

--- a/src/rescle.cc
+++ b/src/rescle.cc
@@ -587,24 +587,24 @@ bool ResourceUpdater::SetIcon(const WCHAR* path, const LANGID& langId,
 
   ScopedFile file(path);
   if (file == INVALID_HANDLE_VALUE) {
-    fwprintf(stderr, "Cannot open icon file '%s'\n", path);
+    fprintf(stderr, "Cannot open icon file '%S'\n", path);
     return false;
   }
 
   IconsValue::ICONHEADER& header = icon.header;
   if (!ReadFile(file, &header, 3 * sizeof(WORD), &bytes, NULL)) {
-    fwprintf(stderr, "Cannot read icon header for '%s'\n", path);
+    fprintf(stderr, "Cannot read icon header for '%S'\n", path);
     return false;
   }
 
   if (header.reserved != 0 || header.type != 1) {
-    fwprintf(stderr, "Reserved header is not 0 or image type is not icon for '%s'\n", path);
+    fprintf(stderr, "Reserved header is not 0 or image type is not icon for '%S'\n", path);
     return false;
   }
 
   header.entries.resize(header.count);
   if (!ReadFile(file, header.entries.data(), header.count * sizeof(IconsValue::ICONENTRY), &bytes, NULL)) {
-    fwprintf(stderr, "Cannot read icon metadata for '%s'\n", path);
+    fprintf(stderr, "Cannot read icon metadata for '%S'\n", path);
     return false;
   }
 
@@ -613,7 +613,7 @@ bool ResourceUpdater::SetIcon(const WCHAR* path, const LANGID& langId,
     icon.images[i].resize(header.entries[i].bytesInRes);
     SetFilePointer(file, header.entries[i].imageOffset, NULL, FILE_BEGIN);
     if (!ReadFile(file, icon.images[i].data(), icon.images[i].size(), &bytes, NULL)) {
-      fwprintf(stderr, "Cannot read icon data for '%s'\n", path);
+      fprintf(stderr, "Cannot read icon data for '%S'\n", path);
       return false;
     }
   }

--- a/src/rescle.cc
+++ b/src/rescle.cc
@@ -587,24 +587,24 @@ bool ResourceUpdater::SetIcon(const WCHAR* path, const LANGID& langId,
 
   ScopedFile file(path);
   if (file == INVALID_HANDLE_VALUE) {
-    fprintf(stderr, "Cannot open icon file '%S'\n", path);
+    fwprintf(stderr, (wchar_t*)"Cannot open icon file '%S'\n", path);
     return false;
   }
 
   IconsValue::ICONHEADER& header = icon.header;
   if (!ReadFile(file, &header, 3 * sizeof(WORD), &bytes, NULL)) {
-    fprintf(stderr, "Cannot read icon header for '%S'\n", path);
+    fwprintf(stderr, (wchar_t*)"Cannot read icon header for '%S'\n", path);
     return false;
   }
 
   if (header.reserved != 0 || header.type != 1) {
-    fprintf(stderr, "Reserved header is not 0 or image type is not icon for '%S'\n", path);
+    fwprintf(stderr, (wchar_t*)"Reserved header is not 0 or image type is not icon for '%S'\n", path);
     return false;
   }
 
   header.entries.resize(header.count);
   if (!ReadFile(file, header.entries.data(), header.count * sizeof(IconsValue::ICONENTRY), &bytes, NULL)) {
-    fprintf(stderr, "Cannot read icon metadata for '%S'\n", path);
+    fwprintf(stderr, (wchar_t*)"Cannot read icon metadata for '%S'\n", path);
     return false;
   }
 
@@ -613,7 +613,7 @@ bool ResourceUpdater::SetIcon(const WCHAR* path, const LANGID& langId,
     icon.images[i].resize(header.entries[i].bytesInRes);
     SetFilePointer(file, header.entries[i].imageOffset, NULL, FILE_BEGIN);
     if (!ReadFile(file, icon.images[i].data(), icon.images[i].size(), &bytes, NULL)) {
-      fprintf(stderr, "Cannot read icon data for '%S'\n", path);
+      fwprintf(stderr, (wchar_t*)"Cannot read icon data for '%S'\n", path);
       return false;
     }
   }

--- a/src/rescle.cc
+++ b/src/rescle.cc
@@ -587,24 +587,24 @@ bool ResourceUpdater::SetIcon(const WCHAR* path, const LANGID& langId,
 
   ScopedFile file(path);
   if (file == INVALID_HANDLE_VALUE) {
-    fwprintf(stderr, (wchar_t*)"Cannot open icon file '%S'\n", path);
+    fwprintf(stderr, (WCHAR*)"Cannot open icon file '%S'\n", path);
     return false;
   }
 
   IconsValue::ICONHEADER& header = icon.header;
   if (!ReadFile(file, &header, 3 * sizeof(WORD), &bytes, NULL)) {
-    fwprintf(stderr, (wchar_t*)"Cannot read icon header for '%S'\n", path);
+    fwprintf(stderr, (WCHAR*)"Cannot read icon header for '%S'\n", path);
     return false;
   }
 
   if (header.reserved != 0 || header.type != 1) {
-    fwprintf(stderr, (wchar_t*)"Reserved header is not 0 or image type is not icon for '%S'\n", path);
+    fwprintf(stderr, (WCHAR*)"Reserved header is not 0 or image type is not icon for '%S'\n", path);
     return false;
   }
 
   header.entries.resize(header.count);
   if (!ReadFile(file, header.entries.data(), header.count * sizeof(IconsValue::ICONENTRY), &bytes, NULL)) {
-    fwprintf(stderr, (wchar_t*)"Cannot read icon metadata for '%S'\n", path);
+    fwprintf(stderr, (WCHAR*)"Cannot read icon metadata for '%S'\n", path);
     return false;
   }
 
@@ -613,7 +613,7 @@ bool ResourceUpdater::SetIcon(const WCHAR* path, const LANGID& langId,
     icon.images[i].resize(header.entries[i].bytesInRes);
     SetFilePointer(file, header.entries[i].imageOffset, NULL, FILE_BEGIN);
     if (!ReadFile(file, icon.images[i].data(), icon.images[i].size(), &bytes, NULL)) {
-      fwprintf(stderr, (wchar_t*)"Cannot read icon data for '%S'\n", path);
+      fwprintf(stderr, (WCHAR*)"Cannot read icon data for '%S'\n", path);
       return false;
     }
   }

--- a/src/rescle.cc
+++ b/src/rescle.cc
@@ -587,24 +587,24 @@ bool ResourceUpdater::SetIcon(const WCHAR* path, const LANGID& langId,
 
   ScopedFile file(path);
   if (file == INVALID_HANDLE_VALUE) {
-    fwprintf(stderr, (WCHAR*)"Cannot open icon file '%S'\n", path);
+    fwprintf(stderr, L"Cannot open icon file '%ls'\n", path);
     return false;
   }
 
   IconsValue::ICONHEADER& header = icon.header;
   if (!ReadFile(file, &header, 3 * sizeof(WORD), &bytes, NULL)) {
-    fwprintf(stderr, (WCHAR*)"Cannot read icon header for '%S'\n", path);
+    fwprintf(stderr, L"Cannot read icon header for '%ls'\n", path);
     return false;
   }
 
   if (header.reserved != 0 || header.type != 1) {
-    fwprintf(stderr, (WCHAR*)"Reserved header is not 0 or image type is not icon for '%S'\n", path);
+    fwprintf(stderr, L"Reserved header is not 0 or image type is not icon for '%ls'\n", path);
     return false;
   }
 
   header.entries.resize(header.count);
   if (!ReadFile(file, header.entries.data(), header.count * sizeof(IconsValue::ICONENTRY), &bytes, NULL)) {
-    fwprintf(stderr, (WCHAR*)"Cannot read icon metadata for '%S'\n", path);
+    fwprintf(stderr, L"Cannot read icon metadata for '%ls'\n", path);
     return false;
   }
 
@@ -613,7 +613,7 @@ bool ResourceUpdater::SetIcon(const WCHAR* path, const LANGID& langId,
     icon.images[i].resize(header.entries[i].bytesInRes);
     SetFilePointer(file, header.entries[i].imageOffset, NULL, FILE_BEGIN);
     if (!ReadFile(file, icon.images[i].data(), icon.images[i].size(), &bytes, NULL)) {
-      fwprintf(stderr, (WCHAR*)"Cannot read icon data for '%S'\n", path);
+      fwprintf(stderr, L"Cannot read icon data for '%ls'\n", path);
       return false;
     }
   }


### PR DESCRIPTION
My code in #74 was not quite right - it would only print the first character of a file path. This fixes it, thanks to @MarshallOfSound for the actual solution.