### PR TITLE
Fix bug #50: Update the PE checksum after committing changes

### DIFF
--- a/rcedit.gyp
+++ b/rcedit.gyp
@@ -10,6 +10,9 @@
         'src/rcedit.rc',
         'src/version.h',
       ],
+      'libraries': [
+        'imagehlp.lib',
+      ],
       'msvs_settings': {
         'VCLinkerTool': {
           'SubSystem': 1, # console executable

--- a/rcedit.vcxproj
+++ b/rcedit.vcxproj
@@ -45,7 +45,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
-      <AdditionalDependencies></AdditionalDependencies>
+      <AdditionalDependencies>imagehlp.lib</AdditionalDependencies>
       <OutputFile>$(OutDir)$(ProjectName)$(TargetExt)</OutputFile>
       <SubSystem>Console</SubSystem>
     </Link>

--- a/src/rescle.h
+++ b/src/rescle.h
@@ -167,7 +167,7 @@ class ResourceUpdater {
 
 class ScopedResourceUpdater {
  public:
-  ScopedResourceUpdater(const WCHAR* filename, bool deleteOld);
+  ScopedResourceUpdater(std::wstring filename, bool deleteOld);
   ~ScopedResourceUpdater();
 
   HANDLE Get() const;
@@ -175,7 +175,9 @@ class ScopedResourceUpdater {
 
  private:
   bool EndUpdate(bool doesCommit);
+  bool UpdateChecksum();
 
+  std::wstring filename_;
   HANDLE handle_;
   bool commited_ = false;
 };


### PR DESCRIPTION
(And fixes duplicate bug #101: Triggers false positive for windows defender golang)

Yes, I was lazy and didn't bother to use GetLastError anywhere, because none of the other code does it...