### PR TITLE
docs: Update build instructions to match CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To build you need CMake 3.15+ and Visual Studio 2015 or above.
 2. Create a build directory: `cmake -E make_directory build`
 3. Change to the build directory: `cd build`
 4. Make the CMake project: `cmake ..`
-5. Build: `cmake --build .`
+5. Build: `cmake --build . --config RelWithDebInfo`
 
 ## Docs
 


### PR DESCRIPTION
When building locally with the `cmake --build .` instructions in the README, I get the following error:

```
cl : command line error D8016: '/Ox' and '/RTC1' command-line options are incompatible [D:\path\to\src\rcedit\b
uild\rcedit.vcxproj]
```

Sounds like this failure is because CMake is trying to include runtime error checks (`/RTC1`) but also produce fully optimized code (`/Ox`) which isn't supported.

I looked at what the CI job is doing, and it apparently passes a `--config RelWithDebInfo` flag to cmake. When I added that locally, the build succeeded. Updating the docs to include that flag seems like the easiest solution, but I'm open to other ideas as well (like only adding `add_compile_options(/Ox /Os)` for release builds).

Fixes #159